### PR TITLE
feat: add inline resume download loading and success states

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/nodemailer": "^7.0.1",
         "@vitest/coverage-v8": "3.2.4",
+        "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "tw-animate-css": "^1.3.7",
         "vitest": "^3.2.4",
@@ -876,6 +877,8 @@
     "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/src/components/hero-section.client.test.tsx
+++ b/src/components/hero-section.client.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
-import { vi } from 'vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
 
 // Mock i18n language map so ResumeButton renders predictable links
 vi.mock('@/i18n/i18n', () => ({
@@ -13,38 +12,121 @@ vi.mock('@/i18n/i18n', () => ({
 }))
 
 vi.mock('./ui/dropdown-menu', () => ({
-	DropdownMenu: ({ children }: any) => <>{children}</>,
-	DropdownMenuTrigger: ({ children, render }: any) => (
-		<>
-			{render ? React.cloneElement(render, undefined, children) : children}
-		</>
+	DropdownMenu: ({ children, open, onOpenChange }: any) => {
+		const [internalOpen, setInternalOpen] = React.useState(false)
+		const isControlled = open !== undefined
+		const actualOpen = isControlled ? open : internalOpen
+
+		return (
+			<div data-open={actualOpen}>
+				{React.Children.map(children, (child: any) =>
+					React.isValidElement(child)
+						? React.cloneElement(child, {
+								__dropdownOpen: actualOpen,
+								__setDropdownOpen: (next: boolean) => {
+									if (!isControlled) {
+										setInternalOpen(next)
+									}
+									onOpenChange?.(next)
+								},
+							})
+						: child
+				)}
+			</div>
+		)
+	},
+	DropdownMenuTrigger: ({ children, render, __dropdownOpen, __setDropdownOpen }: any) =>
+		render
+			? React.cloneElement(render, {
+					onClick: () => __setDropdownOpen(!__dropdownOpen),
+				}, children)
+			: (
+				<button type='button' onClick={() => __setDropdownOpen(!__dropdownOpen)}>
+					{children}
+				</button>
+			),
+	DropdownMenuContent: ({ children, __dropdownOpen }: any) =>
+		__dropdownOpen ? <div>{children}</div> : null,
+	DropdownMenuItem: ({ children, disabled, onSelect }: any) => (
+		<button
+			type='button'
+			disabled={disabled}
+			onClick={(event) => onSelect?.(event)}
+		>
+			{children}
+		</button>
 	),
-	DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
-	DropdownMenuItem: ({ children, render }: any) =>
-		render ? React.cloneElement(render, undefined, children) : <div>{children}</div>,
 }))
 
 import { ResumeButton } from './hero-section.client'
 
 describe('ResumeButton', () => {
-	test('renders trigger and shows resume links for configured languages', async () => {
+	const fetchMock = vi.fn()
+	const createObjectUrlMock = vi.fn(() => 'blob:resume')
+	const revokeObjectUrlMock = vi.fn()
+	const clickMock = vi
+		.spyOn(HTMLAnchorElement.prototype, 'click')
+		.mockImplementation(() => {})
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+		fetchMock.mockReset()
+		createObjectUrlMock.mockClear()
+		revokeObjectUrlMock.mockClear()
+		clickMock.mockClear()
+		vi.stubGlobal('fetch', fetchMock)
+		vi.stubGlobal('URL', {
+			createObjectURL: createObjectUrlMock,
+			revokeObjectURL: revokeObjectUrlMock,
+		})
+	})
+
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.unstubAllGlobals()
+	})
+
+	test('shows loading then success state for the selected language and resets after 4 seconds', async () => {
+		fetchMock.mockResolvedValue({
+			ok: true,
+			blob: vi.fn().mockResolvedValue(new Blob(['resume'])),
+			headers: {
+				get: vi.fn(() => 'attachment; filename="resume-id.pdf"'),
+			},
+		})
+
 		render(<ResumeButton />)
 
-		// The trigger button contains the visible label "Resume"
 		const trigger = screen.getByRole('button', { name: /resume/i })
 		expect(trigger).toBeInTheDocument()
 
-		// Click to open dropdown content
-		await userEvent.click(trigger)
+		fireEvent.click(trigger)
 
-		// Links should exist for each mocked language
-		const enLink = screen.getByRole('link', { name: /English/i })
-		const idLink = screen.getByRole('link', { name: /Bahasa/i })
-		expect(enLink).toBeInTheDocument()
-		expect(idLink).toBeInTheDocument()
+		const indonesianItem = screen.getByRole('button', { name: /bahasa/i })
+		const englishItem = screen.getByRole('button', { name: /english/i })
 
-		// hrefs should point to the expected resume assets
-		expect(enLink.getAttribute('href')).toBe('/resume/en')
-		expect(idLink.getAttribute('href')).toBe('/resume/id')
+		await act(async () => {
+			fireEvent.click(indonesianItem)
+			await Promise.resolve()
+			await Promise.resolve()
+		})
+
+		expect(fetchMock).toHaveBeenCalledWith('/resume/id')
+
+		expect(indonesianItem).toBeDisabled()
+		expect(englishItem).toBeDisabled()
+		expect(screen.getByRole('button', { name: /terima kasih/i })).toBeInTheDocument()
+		expect(screen.queryByRole('button', { name: /bahasa/i })).not.toBeInTheDocument()
+		expect(clickMock).toHaveBeenCalledTimes(1)
+		expect(createObjectUrlMock).toHaveBeenCalledTimes(1)
+		expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:resume')
+
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(4000)
+		})
+
+		expect(screen.getByRole('button', { name: /bahasa/i })).toBeInTheDocument()
+		expect(screen.queryByRole('button', { name: /terima kasih/i })).not.toBeInTheDocument()
+		expect(screen.getByRole('button', { name: /english/i })).toBeEnabled()
 	})
 })

--- a/src/components/hero-section.client.tsx
+++ b/src/components/hero-section.client.tsx
@@ -1,5 +1,6 @@
-import { LANGUAGE_MAP, LANGUAGES } from '@/i18n/i18n'
-import { FileDownIcon } from 'lucide-react'
+import { LANGUAGE_MAP, LANGUAGES, type Language } from '@/i18n/i18n'
+import { CheckIcon, FileDownIcon, LoaderCircleIcon } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { RainbowButton } from './magicui/rainbow-button'
 import {
 	DropdownMenu,
@@ -8,9 +9,81 @@ import {
 	DropdownMenuTrigger,
 } from './ui/dropdown-menu'
 
+const THANK_YOU_LABELS: Record<Language, string> = {
+	en: 'Thank You',
+	id: 'Terima Kasih',
+}
+
+function getDownloadFilename(contentDisposition: string | null, language: Language) {
+	const match = contentDisposition?.match(/filename="([^"]+)"/i)
+
+	return match?.[1] ?? `resume-${language}.pdf`
+}
+
 export function ResumeButton() {
+	const [open, setOpen] = useState(false)
+	const [activeLanguage, setActiveLanguage] = useState<Language | null>(null)
+	const [status, setStatus] = useState<'idle' | 'loading' | 'success'>('idle')
+	const resetTimeoutRef = useRef<number | null>(null)
+
+	useEffect(() => {
+		return () => {
+			if (resetTimeoutRef.current !== null) {
+				window.clearTimeout(resetTimeoutRef.current)
+			}
+		}
+	}, [])
+
+	async function handleDownload(language: Language) {
+		if (status !== 'idle') {
+			return
+		}
+
+		setOpen(true)
+		setActiveLanguage(language)
+		setStatus('loading')
+
+		try {
+			if (resetTimeoutRef.current !== null) {
+				window.clearTimeout(resetTimeoutRef.current)
+				resetTimeoutRef.current = null
+			}
+
+			const response = await fetch(`/resume/${language}`)
+
+			if (!response.ok) {
+				throw new Error(`Failed to download resume for ${language}`)
+			}
+
+			const blob = await response.blob()
+			const objectUrl = URL.createObjectURL(blob)
+			const link = document.createElement('a')
+
+			link.href = objectUrl
+			link.download = getDownloadFilename(
+				response.headers.get('content-disposition'),
+				language
+			)
+			document.body.appendChild(link)
+			link.click()
+			link.remove()
+			URL.revokeObjectURL(objectUrl)
+
+			setStatus('success')
+			resetTimeoutRef.current = window.setTimeout(() => {
+				setStatus('idle')
+				setActiveLanguage(null)
+				resetTimeoutRef.current = null
+			}, 4000)
+		} catch (error) {
+			console.error(error)
+			setStatus('idle')
+			setActiveLanguage(null)
+		}
+	}
+
 	return (
-		<DropdownMenu>
+		<DropdownMenu open={open} onOpenChange={setOpen}>
 			<DropdownMenuTrigger render={<RainbowButton variant='outline' />}>
 				Resume
 				<FileDownIcon />
@@ -19,15 +92,28 @@ export function ResumeButton() {
 				{LANGUAGES.map((language) => (
 					<DropdownMenuItem
 						key={language}
-						render={
-							<a
-								href={`/resume/${language}`}
-								target='_blank'
-								rel='noopener noreferrer'
-							/>
-						}
+						disabled={status !== 'idle'}
+						onSelect={(event) => {
+							event.preventDefault()
+							void handleDownload(language)
+						}}
+						className='data-disabled:cursor-wait data-disabled:opacity-60'
 					>
-						{LANGUAGE_MAP[language].emoji} {LANGUAGE_MAP[language].name}
+						{activeLanguage === language && status === 'loading' ? (
+							<LoaderCircleIcon
+								className='size-4 animate-spin text-muted-foreground'
+								aria-hidden='true'
+							/>
+						) : activeLanguage === language && status === 'success' ? (
+							<CheckIcon className='size-4 text-green-600' aria-hidden='true' />
+						) : (
+							<span aria-hidden='true'>{LANGUAGE_MAP[language].emoji}</span>
+						)}
+						<span>
+							{activeLanguage === language && status === 'success'
+								? THANK_YOU_LABELS[language]
+								: LANGUAGE_MAP[language].name}
+						</span>
 					</DropdownMenuItem>
 				))}
 			</DropdownMenuContent>


### PR DESCRIPTION
## Summary
- replace resume dropdown links with a same-tab download flow driven from the client
- keep the dropdown open while downloading, show a spinner in place of the language flag, and visibly disable the items during the request
- show a localized success state with a green checkmark and thank-you copy for 4 seconds after download

## Details
The resume dropdown now fetches the existing \/resume\/{language} routes and triggers the file download programmatically instead of opening a new tab. The active language item preserves the open menu state, swaps from the flag emoji to a loading spinner during the request, and then shows localized success copy such as  or  with a green checkmark before resetting.

The download handler also reads the  header so the downloaded file keeps the server-provided filename when available, with a fallback filename if the header is missing.

## Testing
- npm test -- src/components/hero-section.client.test.tsx